### PR TITLE
Patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SupportBot v1.7.2b
+# SupportBot v1.7.2
 League of Legends Statistics for Discord
 (c) 2018; source available, all rights reserved
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SupportBot v1.7.1
+# SupportBot v1.7.2b
 League of Legends Statistics for Discord
 (c) 2018; source available, all rights reserved
 

--- a/api/main.js
+++ b/api/main.js
@@ -7,7 +7,7 @@ let CONFIG;
 const JSON5 = require("json5");
 try {
 	CONFIG = JSON5.parse(fs.readFileSync("../" + argv_options.config, "utf-8"));
-	CONFIG.VERSION = "v1.7.1";//b for non-release (in development)
+	CONFIG.VERSION = "v1.7.2b";//b for non-release (in development)
 }
 catch (e) {
 	console.log("something's wrong with config.json");

--- a/api/main.js
+++ b/api/main.js
@@ -78,7 +78,7 @@ const express = require("express");
 const website = express();
 
 const UTILS = new (require("../utils/utils.js"))();
-let Profiler = require("../timeprofiler.js");
+let Profiler = require("../utils/timeprofiler.js");
 let request = require("request");
 let wsRoutes = require("./websockets.js");
 let routes = require("./routes.js");

--- a/api/main.js
+++ b/api/main.js
@@ -7,7 +7,7 @@ let CONFIG;
 const JSON5 = require("json5");
 try {
 	CONFIG = JSON5.parse(fs.readFileSync("../" + argv_options.config, "utf-8"));
-	CONFIG.VERSION = "v1.7.2b";//b for non-release (in development)
+	CONFIG.VERSION = "v1.7.2";//b for non-release (in development)
 }
 catch (e) {
 	console.log("something's wrong with config.json");

--- a/discord/discordcommands.js
+++ b/discord/discordcommands.js
@@ -216,12 +216,12 @@ module.exports = function (CONFIG, client, msg, wsapi, sendToChannel, sendEmbedT
 	command([preferences.get("prefix") + "releasenotify "], true, CONFIG.CONSTANTS.BOTOWNERS, (original, index, parameter) => {
 		wsapi.lnotify(msg.author.username, msg.author.displayAvatarURL, parameter, true);
 	});
-	command([preferences.get("prefix") + "testembed"], false, false, () => {
+	command([preferences.get("prefix") + "testembed"], false, CONFIG.CONSTANTS.BOTOWNERS, () => {
 		replyEmbed(embedgenerator.test("Original behavior"));
 		replyEmbed([{ r: embedgenerator.test("t=0 only"), t: 0 }]);
 		replyEmbed([{ r: embedgenerator.test("t=0"), t: 0 }, { r: embedgenerator.test("t=5000"), t: 5000 }, { r: embedgenerator.test("t=10000"), t: 10000 }, { r: embedgenerator.test("t=15000"), t: 15000 }]);
 	});
-	command([preferences.get("prefix") + "testreply"], false, false, () => {
+	command([preferences.get("prefix") + "testreply"], false, CONFIG.CONSTANTS.BOTOWNERS, () => {
 		reply("Original behavior");
 		reply([{ r: "t=0 only", t: 0 }]);
 		reply([{ r: "t=0", t: 0 }, { r: "t=5000", t: 5000 }, { r: "t=10000", t: 10000 }, { r: "t=15000", t: 15000 }]);

--- a/discord/discordcommands.js
+++ b/discord/discordcommands.js
@@ -938,8 +938,8 @@ module.exports = function (CONFIG, client, msg, wsapi, sendToChannel, sendEmbedT
 					if (UTILS.exists(callback)) callback(nMsg);
 					for (let i = 1; i < reply_embed.length; ++i) {
 						setTimeout(() => {
-							nMsg.edit("", { embed: reply_text[i].r }).catch(e => UTILS.debug(e));
-						}, reply_text[i].t);
+							nMsg.edit("", { embed: reply_embed[i].r }).catch(e => UTILS.debug(e));
+						}, reply_embed[i].t);
 					}
 				}).catch((e) => {
 					console.error(e);
@@ -967,8 +967,8 @@ module.exports = function (CONFIG, client, msg, wsapi, sendToChannel, sendEmbedT
 				if (UTILS.exists(callback)) callback(nMsg);
 				for (let i = 1; i < reply_embed.length; ++i) {
 					setTimeout(() => {
-						nMsg.edit("", { embed: reply_text[i].r }).catch(e => UTILS.debug(e));
-					}, reply_text[i].t);
+						nMsg.edit("", { embed: reply_embed[i].r }).catch(e => UTILS.debug(e));
+					}, reply_embed[i].t);
 				}
 			}).catch((e) => {
 				console.error(e);

--- a/discord/discordcommands.js
+++ b/discord/discordcommands.js
@@ -221,6 +221,11 @@ module.exports = function (CONFIG, client, msg, wsapi, sendToChannel, sendEmbedT
 		replyEmbed([{ r: embedgenerator.test("t=0 only"), t: 0 }]);
 		replyEmbed([{ r: embedgenerator.test("t=0"), t: 0 }, { r: embedgenerator.test("t=5000"), t: 5000 }, { r: embedgenerator.test("t=10000"), t: 10000 }, { r: embedgenerator.test("t=15000"), t: 15000 }]);
 	});
+	command([preferences.get("prefix") + "testreply"], false, false, () => {
+		reply("Original behavior");
+		reply([{ r: "t=0 only", t: 0 }]);
+		reply([{ r: "t=0", t: 0 }, { r: "t=5000", t: 5000 }, { r: "t=10000", t: 10000 }, { r: "t=15000", t: 15000 }]);
+	});
 	command([preferences.get("prefix") + "sd ", preferences.get("prefix") + "summonerdebug "], true, false, (original, index, parameter) => {
 		lolapi.getSummonerIDFromName(assertRegion(parameter.substring(0, parameter.indexOf(" "))), parameter.substring(parameter.indexOf(" ") + 1), CONFIG.API_MAXAGE.SD).then(result => {
 			result.guess = parameter.substring(parameter.indexOf(" ") + 1);

--- a/discord/discordcommands.js
+++ b/discord/discordcommands.js
@@ -217,7 +217,9 @@ module.exports = function (CONFIG, client, msg, wsapi, sendToChannel, sendEmbedT
 		wsapi.lnotify(msg.author.username, msg.author.displayAvatarURL, parameter, true);
 	});
 	command([preferences.get("prefix") + "testembed"], false, false, () => {
-		replyEmbed(embedgenerator.test());
+		replyEmbed(embedgenerator.test("Original behavior"));
+		replyEmbed([{ r: embedgenerator.test("t=0 only"), t: 0 }]);
+		replyEmbed([{ r: embedgenerator.test("t=0"), t: 0 }, { r: embedgenerator.test("t=5000"), t: 5000 }, { r: embedgenerator.test("t=10000"), t: 10000 }, { r: embedgenerator.test("t=15000"), t: 15000 }]);
 	});
 	command([preferences.get("prefix") + "sd ", preferences.get("prefix") + "summonerdebug "], true, false, (original, index, parameter) => {
 		lolapi.getSummonerIDFromName(assertRegion(parameter.substring(0, parameter.indexOf(" "))), parameter.substring(parameter.indexOf(" ") + 1), CONFIG.API_MAXAGE.SD).then(result => {

--- a/discord/embedgenerator.js
+++ b/discord/embedgenerator.js
@@ -258,10 +258,10 @@ function transformTimelineToArray(match, timeline) {
 }
 module.exports = class EmbedGenerator {
 	constructor() { }
-	test() {
+	test(x = "") {
 		let newEmbed = new Discord.RichEmbed();
 		newEmbed.setAuthor("Author \\🇺🇸");
-		newEmbed.setTitle("Test 🇺🇸");
+		newEmbed.setTitle("Test 🇺🇸: " + x);
 		newEmbed.setDescription("description 🇺🇸");
 		newEmbed.addField("field title 🇺🇸", "field desc 🇺🇸");
 		newEmbed.setFooter("Footer 🇺🇸");

--- a/discord/shard.js
+++ b/discord/shard.js
@@ -17,7 +17,7 @@ let CONFIG;
 const JSON5 = require("json5");
 try {
 	CONFIG = JSON5.parse(fs.readFileSync("../" + argv_options.config, "utf-8"));
-	CONFIG.VERSION = "v1.7.2b";//b for non-release (in development)
+	CONFIG.VERSION = "v1.7.2";//b for non-release (in development)
 	CONFIG.BANS = {};
 }
 catch (e) {

--- a/discord/shard.js
+++ b/discord/shard.js
@@ -17,7 +17,7 @@ let CONFIG;
 const JSON5 = require("json5");
 try {
 	CONFIG = JSON5.parse(fs.readFileSync("../" + argv_options.config, "utf-8"));
-	CONFIG.VERSION = "v1.7.1";//b for non-release (in development)
+	CONFIG.VERSION = "v1.7.2b";//b for non-release (in development)
 	CONFIG.BANS = {};
 }
 catch (e) {


### PR DESCRIPTION
- [bugfix] requiring timeprofiler in /api/main.js fixed to new /utils/ folder
- [internal][feature] reply() family of commands in discordcommands.js now accepts arrays so scheduled messages are now possible
- [internal][feature] `Ltestreply` now a command
- [internal][breaking] `Ltestembed` and `Ltestreply` now require bot owner permissions.