### PR TITLE
Patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ League of Legends Statistics for Discord
   - Server moderators
   - Server bot commanders
   - Normal members
+- Records of all commands used
+  - Time to respond
+  - Cache hit rate
+  - All related IDs
+  - Audit logs automatically remove entries older than 1 year (default)
 ## Format of Repository
 ### Branches:
 - major: unstable, next major revision v+.0.0 : we removed a feature

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SupportBot v1.7.2
+# SupportBot v1.7.3b
 League of Legends Statistics for Discord
 (c) 2018; source available, all rights reserved
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SupportBot v1.7.3b
+# SupportBot v1.7.3
 League of Legends Statistics for Discord
 (c) 2018; source available, all rights reserved
 

--- a/api/main.js
+++ b/api/main.js
@@ -7,7 +7,7 @@ let CONFIG;
 const JSON5 = require("json5");
 try {
 	CONFIG = JSON5.parse(fs.readFileSync("../" + argv_options.config, "utf-8"));
-	CONFIG.VERSION = "v1.7.2";//b for non-release (in development)
+	CONFIG.VERSION = "v1.7.3b";//b for non-release (in development)
 }
 catch (e) {
 	console.log("something's wrong with config.json");

--- a/api/main.js
+++ b/api/main.js
@@ -168,7 +168,8 @@ let server_preferences_doc = new apicache.Schema({
 	//region: { type: String, required: true, default: "" },//default server region, LoL ("" = disabled)
 	auto_opgg: { type: Boolean, required: true, default: true },//automatically embed respond to op.gg links
 	force_prefix: { type: Boolean, required: true, default: false },
-	release_notifications: { type: Boolean, required: true, default: true }
+	release_notifications: { type: Boolean, required: true, default: true },
+	feedback_enabled: { type: Boolean, required: true, default: true}
 	//music
 	/*
 	max_music_length: { type: Number, required: true, default: 360 },//in seconds

--- a/api/main.js
+++ b/api/main.js
@@ -65,7 +65,7 @@ let riotRequest = new (require("riot-lol-api"))(CONFIG.RIOT_API_KEY, 12000, {
 	},
 	set: function(region, endpoint, cacheStrategy, data) {
 		const oldFormat = endpointToURL(region, endpoint);
-		if (cacheStrategy.cachetime != 0) addCache(oldFormat.url, JSON.stringify(data), cacheStrategy.cachetime);
+		if (cacheStrategy.cachetime != 0 && !(UTILS.exists(data.status) && data.status.status_code >= 500)) addCache(oldFormat.url, JSON.stringify(data), cacheStrategy.cachetime);
 		else;
 	}
 });

--- a/api/main.js
+++ b/api/main.js
@@ -7,7 +7,7 @@ let CONFIG;
 const JSON5 = require("json5");
 try {
 	CONFIG = JSON5.parse(fs.readFileSync("../" + argv_options.config, "utf-8"));
-	CONFIG.VERSION = "v1.7.3b";//b for non-release (in development)
+	CONFIG.VERSION = "v1.7.3";//b for non-release (in development)
 }
 catch (e) {
 	console.log("something's wrong with config.json");

--- a/discord/discordcommands.js
+++ b/discord/discordcommands.js
@@ -151,26 +151,28 @@ module.exports = function (CONFIG, client, msg, wsapi, sendToChannel, sendEmbedT
 			replyEmbed(embedgenerator.actionReport(CONFIG, parameter, results[parameter]));
 		}).catch();
 	});
-	command([preferences.get("prefix") + "complain ", preferences.get("prefix") + "praise ", preferences.get("prefix") + "suggest "], true, false, (original, index) => {
-		lolapi.userHistory(msg.author.id).then(uH => {
-			if (!msg.PM) lolapi.serverHistory(msg.guild.id).then(gH => step2(gH[msg.guild.id])).catch(console.error);
-			else step2(null);
-			function step2(gH) {
-				sendEmbedToChannel(CONFIG.FEEDBACK.EXTERNAL_CID, embedgenerator.feedback(CONFIG, index + 1, 1, msg, uH[msg.author.id], gH), true);
-				reply(":white_check_mark: Thank you for your feedback!");
-			}
-		}).catch(console.error);
-	});
-	command([preferences.get("prefix") + "question ", preferences.get("prefix") + "ask "], true, false, (original, index) => {
-		lolapi.userHistory(msg.author.id).then(uH => {
-			if (!msg.PM) lolapi.serverHistory(msg.guild.id).then(gH => step2(gH[msg.guild.id]));
-			else step2(null);
-			function step2(gH) {
-				sendEmbedToChannel(CONFIG.FEEDBACK.EXTERNAL_CID, embedgenerator.feedback(CONFIG, 4, 1, msg, uH[msg.author.id], gH));
-				reply(":white_check_mark: Thank you for your question! Someone from our staff will respond by SupportBot PM as soon as possible.");
-			}
+	if (preferences.get("feedback_enabled")) {
+		command([preferences.get("prefix") + "complain ", preferences.get("prefix") + "praise ", preferences.get("prefix") + "suggest "], true, false, (original, index) => {
+			lolapi.userHistory(msg.author.id).then(uH => {
+				if (!msg.PM) lolapi.serverHistory(msg.guild.id).then(gH => step2(gH[msg.guild.id])).catch(console.error);
+				else step2(null);
+				function step2(gH) {
+					sendEmbedToChannel(CONFIG.FEEDBACK.EXTERNAL_CID, embedgenerator.feedback(CONFIG, index + 1, 1, msg, uH[msg.author.id], gH), true);
+					reply(":white_check_mark: Thank you for your feedback!");
+				}
+			}).catch(console.error);
 		});
-	});
+		command([preferences.get("prefix") + "question ", preferences.get("prefix") + "ask "], true, false, (original, index) => {
+			lolapi.userHistory(msg.author.id).then(uH => {
+				if (!msg.PM) lolapi.serverHistory(msg.guild.id).then(gH => step2(gH[msg.guild.id]));
+				else step2(null);
+				function step2(gH) {
+					sendEmbedToChannel(CONFIG.FEEDBACK.EXTERNAL_CID, embedgenerator.feedback(CONFIG, 4, 1, msg, uH[msg.author.id], gH));
+					reply(":white_check_mark: Thank you for your question! Someone from our staff will respond by SupportBot PM as soon as possible.");
+				}
+			});
+		});
+	}
 	command([preferences.get("prefix") + "permissionstest", preferences.get("prefix") + "pt"], false, false, () => {
 		reply("You have " + ["normal", "bot commander", "moderator", "server admin", "server owner", "bot owner"][ACCESS_LEVEL] + " permissions.");
 	});
@@ -606,6 +608,10 @@ module.exports = function (CONFIG, client, msg, wsapi, sendToChannel, sendEmbedT
 		command([preferences.get("prefix") + "setting release-notifications on", preferences.get("prefix") + "setting release-notifications off"], false, CONFIG.CONSTANTS.ADMINISTRATORS, (original, index) => {
 			const new_setting = index === 0 ? true : false;
 			preferences.set("release_notifications", new_setting).then(() => reply(":white_check_mark: " + (new_setting ? "SupportBot will show new release notifications." : "SupportBot will not show new release notifications."))).catch(reply);
+		});
+		command([preferences.get("prefix") + "setting global-feedback on", preferences.get("prefix") + "setting global-feedback off"], false, CONFIG.CONSTANTS.MODERATORS, (original, index) => {
+			const new_setting = index === 0 ? true : false;
+			preferences.set("feedback_enabled", new_setting).then(() => reply(":white_check_mark: " + (new_setting ? "SupportBot will allow the use of global feedback commands in this server." : "SupportBot will not allow the use of global feedback commands in this server."))).catch(reply);
 		});
 		command(["supportbot settings reset all"], false, CONFIG.CONSTANTS.ADMINISTRATORS, () => reply(":warning: You are about to reset all the preferences associated with this server. To confirm this action, please send the command: `supportbot settings reset all confirm`"));
 		command(["supportbot settings reset all confirm"], false, CONFIG.CONSTANTS.ADMINISTRATORS, () => {

--- a/discord/embedgenerator.js
+++ b/discord/embedgenerator.js
@@ -1267,7 +1267,7 @@ module.exports = class EmbedGenerator {
 			public_e.setAuthor(username, public_e.author.icon_url);
 			edit.setFooter("Approved by " + approver.username, approver.displayAvatarURL);
 			edit.fields = [];
-			edit.addField("Responses", "Send message response: `" + CONFIG.DISCORD_COMMAND_PREFIX + "mail <text>" + uid + "`\nNote: `" + CONFIG.DISCORD_COMMAND_PREFIX + "noteuser " + uid + " <reason>`");
+			edit.addField("Responses", "Send message response: `" + CONFIG.DISCORD_COMMAND_PREFIX + "mail " + uid + " <text>`\nNote: `" + CONFIG.DISCORD_COMMAND_PREFIX + "noteuser " + uid + " <reason>`");
 			user.setAuthor(username, msg.embeds[0].author.icon, msg.embeds[0].author.url);
 			user.setFooter("Approved by " + approver.username, approver.displayAvatarURL);
 			user.fields = [];
@@ -1283,7 +1283,7 @@ module.exports = class EmbedGenerator {
 			const username = msg.embeds[0].footer.text.substring(c_location2 + 1);
 			edit.setFooter("Denied by " + approver.username, approver.displayAvatarURL);
 			edit.fields = [];
-			edit.addField("Responses", "Send message response: `" + CONFIG.DISCORD_COMMAND_PREFIX + "mail <text>" + uid + "`\nNote: `" + CONFIG.DISCORD_COMMAND_PREFIX + "noteuser " + uid + " <reason>`");
+			edit.addField("Responses", "Send message response: `" + CONFIG.DISCORD_COMMAND_PREFIX + "mail " + uid + " <text>`\nNote: `" + CONFIG.DISCORD_COMMAND_PREFIX + "noteuser " + uid + " <reason>`");
 			edit.setColor("#010101");
 			return { edit };
 		}

--- a/discord/embedgenerator.js
+++ b/discord/embedgenerator.js
@@ -51,7 +51,10 @@ const queues = {
 	"1050": "OE Crewmember",
 	"1060": "OE Captain",
 	"1070": "OE Onslaught",
-	"1200": "NB Nexus Blitz"
+	"1200": "NB Nexus Blitz",
+	"2000": "SR Tutorial 1",
+	"2010": "SR Tutorial 2",
+	"2020": "SR Tutorial 3"
 };
 const MMR_JOKES = [
 	["We recommend using a mouse and keyboard when playing League of Legends.",//below bronze

--- a/discord/preferences.js
+++ b/discord/preferences.js
@@ -22,7 +22,8 @@ const newPreferences = {
 	slow: 0,//self slow mode
 	auto_opgg: true, //automatically embed respond to op.gg links
 	force_prefix: false,//force commands that don't require a prefix to use a prefix
-	release_notifications: true//accept Lnotifys for new releases
+	release_notifications: true,//accept Lnotifys for new releases
+	feedback_enabled: true//allow use of global feedback commands
 };
 const preferencesFormat = {
 	id: "string",//id of server
@@ -31,7 +32,8 @@ const preferencesFormat = {
 	slow: "number",//self slow mode
 	auto_opgg: "boolean",//automatically embed respond to op.gg links
 	force_prefix: "boolean",//
-	release_notifications: "boolean"//
+	release_notifications: "boolean",//
+	feedback_enabled: "boolean"
 };
 module.exports = class Preferences {
 	constructor(lolapi, guild, callback) {

--- a/discord/shard.js
+++ b/discord/shard.js
@@ -17,7 +17,7 @@ let CONFIG;
 const JSON5 = require("json5");
 try {
 	CONFIG = JSON5.parse(fs.readFileSync("../" + argv_options.config, "utf-8"));
-	CONFIG.VERSION = "v1.7.2";//b for non-release (in development)
+	CONFIG.VERSION = "v1.7.3b";//b for non-release (in development)
 	CONFIG.BANS = {};
 }
 catch (e) {

--- a/discord/shard.js
+++ b/discord/shard.js
@@ -39,10 +39,8 @@ loadAllStaticResources(() => {
 let initial_start = true;
 client.on("ready", function () {
 	UTILS.output(initial_start ? "discord user login success" : "discord reconnected");
-	if (process.env.SHARD_ID == 0) {
-		client.user.setStatus("idle").catch(console.error);
-		client.user.setActivity("Starting Up").catch(console.error);
-	}
+	client.user.setStatus("idle").catch(console.error);
+	client.user.setActivity("Starting Up").catch(console.error);
 	sendToChannel(CONFIG.LOG_CHANNEL_ID, initial_start ? ":repeat:`$" + process.env.SHARD_ID + "`Bot started in " + UTILS.round((new Date().getTime() - start_time) / 1000, 0) + "s: version: " + CONFIG.VERSION + " mode: " + mode + " servers: " + client.guilds.size : ":repeat:`$" + process.env.SHARD_ID + "`Bot reconnected");
 	wsapi.sendEmojis(allEmojis());
 	wsapi.getUserBans();

--- a/discord/shard.js
+++ b/discord/shard.js
@@ -17,7 +17,7 @@ let CONFIG;
 const JSON5 = require("json5");
 try {
 	CONFIG = JSON5.parse(fs.readFileSync("../" + argv_options.config, "utf-8"));
-	CONFIG.VERSION = "v1.7.3b";//b for non-release (in development)
+	CONFIG.VERSION = "v1.7.3";//b for non-release (in development)
 	CONFIG.BANS = {};
 }
 catch (e) {

--- a/utils/lolapi.js
+++ b/utils/lolapi.js
@@ -324,7 +324,7 @@ module.exports = class LOLAPI {
 			that.getSummonerIDFromName(region, username, this.CONFIG.API_MAXAGE.SUMMONER_CARD.SUMMONER_ID).then(result6 => {
 				result6.region = region;
 				result6.guess = username;
-				if (!UTILS.exists(result6.id)) reject();
+				if (!UTILS.exists(result6.id)) return reject();
 				that.getRanks(region, result6.id, this.CONFIG.API_MAXAGE.SUMMONER_CARD.RANKS).then(result2 => {
 					Promise.all(result2.map(r => that.getChallengerRanks(region, r.queueType, this.CONFIG.API_MAXAGE.SUMMONER_CARD.CHALLENGERS))).then(result5 => {
 						that.getChampionMastery(region, result6.id, this.CONFIG.API_MAXAGE.SUMMONER_CARD.CHAMPION_MASTERY).then(result3 => {

--- a/utils/lolapi.js
+++ b/utils/lolapi.js
@@ -73,6 +73,7 @@ module.exports = class LOLAPI {
 							else resolve(body);
 						}
 						catch (e) {
+							UTILS.output("Failed to parse JSON for:\n" + iurl + "\n" + body);
 							reject(e);
 						}
 					}

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -228,12 +228,10 @@ module.exports = class UTILS {
 				else if (LP < 1000) answer += " +";
 				else answer += "+";
 			}
-			else {
+			else {//all others
 				answer += { "I": "1", "II": "2", "III": "3", "IV": "4" }[info.rank];
-				if (info.wins + info.losses >= 8) answer += " ";
-				else answer += "P";//placements, less than 10 games
-				if (LP < 0) answer += "-";//negative
-				else if (LP < 100) answer += "+";//less than 100
+				if (LP < 0) answer += " -";//negative
+				else if (LP < 100) answer += " +";//less than 100
 				else answer += "+";//=100
 			}
 			LP = Math.abs(LP).pad(2);

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -25,7 +25,7 @@ Number.prototype.pad = function(size) {
 	return s;
 }
 Number.prototype.round = function(decimal = 0) {
-	return decimal < 0 ? Math.round(this * Math.pow(10, decimal)) / Math.pow(10, decimal) : this.toFixed(decimal);
+	return Math.round(this * Math.pow(10, decimal)) / Math.pow(10, decimal);
 }
 module.exports = class UTILS {
 	output(t) {//general utility function
@@ -53,7 +53,7 @@ module.exports = class UTILS {
 		else return "";
 	}
 	round(num, decimal = 0) {
-		return decimal < 0 ? Math.round(num * Math.pow(10, decimal)) / Math.pow(10, decimal) : num.toFixed(decimal);
+		return Math.round(num * Math.pow(10, decimal)) / Math.pow(10, decimal);
 	}
 	assert(condition, message) {
 		if (typeof (condition) != "boolean") {


### PR DESCRIPTION
- [feature] `Lsetting global-feedback <on/off>` allows a server to enable or disable global feedback commands such as `Lcomplain`, `Lpraise`, etc
- [enhancement][bugfix] Tutorial parts 1, 2, and 3 are now valid game modes
- [bugfix] for approval codes `mail`
- [enhancement] IAPI will no longer cache code 500 API responses
- [bugfix] utils rounding function revert to return number only
- [bugfix] discontinue running api requests for summoner that doesn't exist (summoner card command)
- [bugfix] short rank format for 100LP but not in series
- [bugfix] all shards set discord status
- [enhancement] readme.md updated

